### PR TITLE
Optimize loader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-core</artifactId>
-            <version>3.2.0-RC1</version>
+            <version>3.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-bolt-driver</artifactId>
-            <version>3.2.0-RC1</version>
-            <scope>runtime</scope>
+            <version>3.2.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,11 @@
             <version>${jaxb.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
-        </dependency>        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>1.10.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-ogm-bolt-native-types</artifactId>
+            <version>3.2.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>javax.activation</artifactId>
             <version>${javax.activation.version}</version>

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
@@ -19,8 +19,11 @@ import org.neo4j.ogm.transaction.Transaction;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import java.io.*;
 import java.nio.charset.Charset;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -114,7 +117,11 @@ public class PublicFilingLoader {
         }
 
         //  Create a session factory
-        Configuration configuration = new Configuration.Builder().uri(SERVER_URI).credentials(SERVER_USERNAME, SERVER_PASSWORD).build();
+        Configuration configuration = new Configuration.Builder()
+            .uri(SERVER_URI)
+            .credentials(SERVER_USERNAME, SERVER_PASSWORD)
+            .useNativeTypes()
+            .build();
         sessionFactory = new SessionFactory(configuration, "com.buddhadata.sandbox.neo4j.filings.node", "com.buddhadata.sandbox.neo4j.filings.relationship");
 
         //  Get all the caches defined with the appropriate loaders to use during processing
@@ -434,7 +441,9 @@ public class PublicFilingLoader {
     private Filing createFiling (FilingType ft, Client client) {
 
         String amount = ft.getAmount();
-        Filing toReturn = new Filing (ft.getID(), ft.getYear(), ft.getReceived().toGregorianCalendar().getTime(),
+        XMLGregorianCalendar c = ft.getReceived();
+        LocalDateTime receivedOn = LocalDateTime.of(c.getYear(), c.getMonth(), c.getDay(), c.getHour(), c.getMinute(), c.getSecond());
+        Filing toReturn = new Filing (ft.getID(), ft.getYear(), receivedOn,
             Integer.valueOf(amount), ft.getType(), ft.getPeriod(), client);
         return toReturn;
     }

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
@@ -331,10 +331,8 @@ public class PublicFilingLoader {
                 //  Process all the files (zip entries) within the zip file (zip input stream)
                 ZipEntry ze = null;
                 while ((ze = zis.getNextEntry()) != null) {
-                    long start = System.currentTimeMillis();
-
                     //  Unmarshall the XML document into objects that are easier to work with.
-                    PublicFilings filings = getPublicFilings(zis, ze);
+                    PublicFilings filings = getPublicFilings(zis);
 
                     //  Process
                     processFilings(filings, ze.getName());
@@ -370,32 +368,20 @@ public class PublicFilingLoader {
     /**
      * Unmarshall the filings data from the original XML
      * @param zis the stream from which each entry is read
-     * @param ze the zip file entry containing important information about the zip'ed file
      * @return PublicFilings object with 1 or more filings
      */
-    private PublicFilings getPublicFilings (ZipInputStream zis,
-                                            ZipEntry ze) {
+    private PublicFilings getPublicFilings (ZipInputStream zis) {
 
-        PublicFilings toReturn = null;
         try {
-            //  First, read the bytes for this zip entry.
-            byte[] bytes = new byte[(int) ze.getSize() + 2048];
-            int offset = 0;
-            int read = 0;
-            while ((read = zis.read(bytes, offset, 2048)) >= 0) {
-                offset += read;
-            }
 
-            //  Create a reader to stream the bytes and deserialize the XML.
-            try (Reader rdr = new InputStreamReader (new ByteArrayInputStream(bytes, 0, offset), Charset.forName("UTF-16"))) {
-                toReturn = (PublicFilings) unmarshaller.unmarshal(rdr);
-            }
+            return (PublicFilings) unmarshaller.unmarshal(new FilterInputStream(zis) {
+                @Override public void close() {
+                }
+            });
         } catch (Exception e) {
             System.out.println ("Exception while unmarshalling: " + e);
         }
-
-
-        return toReturn;
+        return null;
     }
 
     /**

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
@@ -252,9 +252,9 @@ public class PublicFilingLoader {
                 System.out.print("Processing " + sourceName + ": ");
                 long start = System.currentTimeMillis();
 
-                for (FilingType one : filings.getFiling()) {
+                Session session = sessionFactory.openSession();
 
-                    Session session = sessionFactory.openSession();
+                for (FilingType one : filings.getFiling()) {
 
                     //  Filings with no amount specified are those filed indicating no lobbying activty
                     //  by the registrant in the current quarter

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/PublicFilingLoader.java
@@ -119,9 +119,6 @@ public class PublicFilingLoader {
 
         //  Get all the caches defined with the appropriate loaders to use during processing
         createCaches();
-
-        //  Indices on a few nodes should help querying existing nodes when reusing between filings.
-        createIndices();
     }
 
     /**
@@ -232,6 +229,7 @@ public class PublicFilingLoader {
 
         //  Always clean up by purging the database.
         purgeDatabase();
+        //  Indices on a few nodes should help querying existing nodes when reusing between filings.
         createIndices();
 
         //  If you want to process individual files, do this.

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Client.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Client.java
@@ -4,10 +4,9 @@
 
 package com.buddhadata.sandbox.neo4j.filings.node;
 
-import org.neo4j.ogm.annotation.*;
+import java.util.Objects;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.neo4j.ogm.annotation.*;
 
 /**
  * Node representing a client who's lobbying (lobbying done by a registrant
@@ -28,13 +27,6 @@ public class Client {
      */
     @Property
     private boolean stateLocalGovtInd;
-
-    /**
-     * Internal Neo4J id of the node
-     */
-    @Id
-    @GeneratedValue
-    private Long id;
 
     /**
      * government-issued identifier, should be unique BUT ISN'T!
@@ -69,6 +61,7 @@ public class Client {
     /**
      * Client name
      */
+    @Id
     @Property
     private String name;
 
@@ -120,11 +113,11 @@ public class Client {
         this.stateLocalGovtInd = stateLocalGovtInd;
     }
 
-    /**
-     * Default constructor
-     */
-    public Client () {
-        return;
+    Client() {
+    }
+
+    public Client(String name) {
+        this.name = name;
     }
 
     /**
@@ -157,22 +150,6 @@ public class Client {
      */
     public void setStateLocalGovtInd(boolean stateLocalGovtInd) {
         this.stateLocalGovtInd = stateLocalGovtInd;
-    }
-
-    /**
-     * getter
-     * @return internal Neo4J id of the node
-     */
-    public Long getId() {
-        return id;
-    }
-
-    /**
-     * setter
-     * @param id Neo4J-assigned node id
-     */
-    public void setId(Long id) {
-        this.id = id;
     }
 
     /**
@@ -264,14 +241,6 @@ public class Client {
     }
 
     /**
-     * setter
-     * @param name client's name
-     */
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
      * getter
      * @return client's state, when applicable
      */
@@ -305,23 +274,17 @@ public class Client {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o)
+            return true;
+        if (!(o instanceof Client))
+            return false;
         Client client = (Client) o;
-
-        if (clientId != client.clientId) return false;
-        return name != null ? name.equals(client.name) : client.name == null;
-
+        return name.equals(client.name);
     }
 
-    @Override
-    public int hashCode() {
-        int result = (int) (clientId ^ (clientId >>> 32));
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        return result;
+    @Override public int hashCode() {
+        return Objects.hash(name);
     }
-
 
     /**
      * Normalize the string data provided in the source data file

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Filing.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Filing.java
@@ -6,6 +6,7 @@ package com.buddhadata.sandbox.neo4j.filings.node;
 
 import org.neo4j.ogm.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 /**
@@ -27,7 +28,7 @@ public class Filing {
      * Date on which the filing was received.
      */
     @Property
-    private Date receivedOn;
+    private LocalDateTime receivedOn;
 
     /**
      * The dollar amount of the filing.
@@ -95,7 +96,7 @@ public class Filing {
      */
     public Filing (final String filingId,
                    final int year,
-                   final Date receivedOn,
+                   final LocalDateTime receivedOn,
                    final int amount,
                    final String type,
                    final String period,
@@ -141,7 +142,7 @@ public class Filing {
      * getter
      * @return date on which the filing was received
      */
-    public Date getReceivedOn() {
+    public LocalDateTime getReceivedOn() {
         return receivedOn;
     }
 
@@ -149,7 +150,7 @@ public class Filing {
      * setter
      * @param receivedOn date on which the filing was received
      */
-    public void setReceivedOn(Date receivedOn) {
+    public void setReceivedOn(LocalDateTime receivedOn) {
         this.receivedOn = receivedOn;
     }
 

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/GovernmentEntity.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/GovernmentEntity.java
@@ -4,7 +4,8 @@
 
 package com.buddhadata.sandbox.neo4j.filings.node;
 
-import org.neo4j.ogm.annotation.GeneratedValue;
+import java.util.Objects;
+
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Property;
@@ -18,15 +19,9 @@ import org.neo4j.ogm.annotation.Property;
 public class GovernmentEntity {
 
     /**
-     * Internal Neo4J id of the node
-     */
-    @Id
-    @GeneratedValue
-    private Long id;
-
-    /**
      * Registrant name
      */
+    @Id
     @Property
     private String name;
 
@@ -42,24 +37,7 @@ public class GovernmentEntity {
     /**
      * Default constructor
      */
-    public GovernmentEntity() {
-        return;
-    }
-
-    /**
-     * getter
-     * @return internal Neo4J id of the node
-     */
-    public Long getId() {
-        return id;
-    }
-
-    /**
-     * setter
-     * @param id internal Neo4J id of the node
-     */
-    public void setId(Long id) {
-        this.id = id;
+    GovernmentEntity() {
     }
 
     /**
@@ -85,5 +63,18 @@ public class GovernmentEntity {
      */
     private String normalizeString (String original) {
         return (original != null && !original.isEmpty()) ? original.trim().replace("\r\n", ", ").replace("\n", "  ") : null;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof GovernmentEntity))
+            return false;
+        GovernmentEntity that = (GovernmentEntity) o;
+        return name.equals(that.name);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Issue.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Issue.java
@@ -4,6 +4,8 @@
 
 package com.buddhadata.sandbox.neo4j.filings.node;
 
+import java.util.Objects;
+
 import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
@@ -18,15 +20,9 @@ import org.neo4j.ogm.annotation.Property;
 public class Issue {
 
     /**
-     * Internal Neo4J id of the node
-     */
-    @Id
-    @GeneratedValue
-    private Long id;
-
-    /**
      * general area of the issue, standardized for all issues across filings
      */
+    @Id
     @Property
     private String code;
 
@@ -42,24 +38,7 @@ public class Issue {
     /**
      * Default constructor
      */
-    public Issue() {
-        return;
-    }
-
-    /**
-     * getter
-     * @return internal Neo4J id of the node
-     */
-    public Long getId() {
-        return id;
-    }
-
-    /**
-     * setter
-     * @param id internal Neo4J id of the node
-     */
-    public void setId(Long id) {
-        this.id = id;
+    Issue() {
     }
 
     /**
@@ -78,20 +57,17 @@ public class Issue {
         this.code = code;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Issue))
+            return false;
         Issue issue = (Issue) o;
-
-        return code != null ? code.equals(issue.code) : issue.code == null;
-
+        return code.equals(issue.code);
     }
 
-    @Override
-    public int hashCode() {
-        return code != null ? code.hashCode() : 0;
+    @Override public int hashCode() {
+        return Objects.hash(code);
     }
 
     /**

--- a/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Registrant.java
+++ b/src/main/java/com/buddhadata/sandbox/neo4j/filings/node/Registrant.java
@@ -7,6 +7,7 @@ package com.buddhadata.sandbox.neo4j.filings.node;
 import org.neo4j.ogm.annotation.*;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -17,13 +18,6 @@ import java.util.Set;
 @NodeEntity
 public class Registrant
     implements Comparable<Registrant> {
-
-    /**
-     * Internal Neo4J id of the node
-     */
-    @Id
-    @GeneratedValue
-    private Long id;
 
     /**
      * Registrant's address
@@ -58,6 +52,7 @@ public class Registrant
     /**
      * government-generated ID of registrant
      */
+    @Id
     @Property
     private long registrantId;
 
@@ -65,7 +60,7 @@ public class Registrant
      * The clients which have engaged (hired) this registrant/lobbying firm
      */
     @Relationship(type="ENGAGES", direction="INCOMING")
-    private Set<Client> clients;
+    private Set<Client> clients = new HashSet<>();
 
     /**
      * Constructor
@@ -83,7 +78,6 @@ public class Registrant
                       final String country,
                       final String countryPBB) {
 
-        this();
         this.registrantId = registrantId;
         this.name = normalizeString (name);
         this.description = normalizeString (description);
@@ -95,24 +89,7 @@ public class Registrant
     /**
      * Default constructor
      */
-    public Registrant() {
-        this.clients = new HashSet<>();
-    }
-
-    /**
-     * getter
-     * @return internal Neo4J id of the node
-     */
-    public Long getId() {
-        return id;
-    }
-
-    /**
-     * setter
-     * @param id internal Neo4J id of the node
-     */
-    public void setId(Long id) {
-        this.id = id;
+    Registrant() {
     }
 
     /**
@@ -234,6 +211,19 @@ public class Registrant
      */
     public int compareTo (Registrant other) {
         return getName().compareTo(other.getName());
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Registrant))
+            return false;
+        Registrant that = (Registrant) o;
+        return registrantId == that.registrantId;
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(registrantId);
     }
 
     /**


### PR DESCRIPTION
Hi @scsosna99, 

my friend and colleague @jexp brought this post https://dzone.com/articles/improving-neo4j-ogm-performance to our attention.

Your analysis of the `Neo4jSession` is very detailed and pretty accurate, but leads the reader to thin ice, especially when the reader decides that manipulating the internals is a good idea.

With this pull request I'd like to propose a better solution:

The main idea around the session is: It is a *short lived object* That is: You don't keep it around. When it's used with Spring Data Neo4j, for each transaction a new one is created and that's what we do with the PR.

We keep the `SessionFactory` ( which is expensive to create) and than open sessions as needed. Especially in the `processFilings` methods.
We do the same inside the cache population.

On top of that, I have upgrade to just released version of Neo4j-OGM 3.2.1.
For the creating the indexes and purging the database, I find it much better to `unwrap` the underlying java driver as shown.

As I'm writing this, my 13" MacBook Pro is printing this output:

```
Processing 2015_3_7_17.xml: 716 filings in 2432 ms
Processing 2015_3_7_2.xml: 1000 filings in 4053 ms
Processing 2015_3_7_3.xml: 1000 filings in 4187 ms
Processing 2015_3_7_4.xml: 1000 filings in 6272 ms
Processing 2015_3_7_5.xml: 1000 filings in 7010 ms
Processing 2015_3_7_6.xml: 1000 filings in 5644 ms
Processing 2015_3_7_7.xml: 1000 filings in 6520 ms
Processing 2015_3_7_8.xml: 1000 filings in 5534 ms
Processing 2015_3_7_9.xml: 1000 filings in 4783 ms
Processing 2015_3_8_1.xml: 1000 filings in 2704 ms
Processing 2015_3_8_2.xml: 226 filings in 620 ms
Processing 2015_3_9_1.xml: 703 filings in 1702 ms
Processing 2015_4_10_1.xml: 1000 filings in 3988 ms
```

I really hope this PR made it's way into your project and in a potential update to your otherwise grate post on DZone.

Thanks,
Michael.
